### PR TITLE
printing rank and file on left side and below board

### DIFF
--- a/src/chess/Game.scala
+++ b/src/chess/Game.scala
@@ -41,15 +41,4 @@ object Game {
     History.clear()
     new Game(GameBoard.newBoard(), White)
   }
-  def printSomething = {
-    println("hi")
-  }
-  class Square(val name: String) {
-    final val a2 = {
-      println("moving " + name + " " + "a2")
-      Game.newGame().move(name + " " + "a2")
-    }
-  }
-  final val a1 = new Square("a1")
-  final val a2 = new Square("a2")
 }

--- a/src/chess/GameBoard.scala
+++ b/src/chess/GameBoard.scala
@@ -51,13 +51,17 @@ case class GameBoard(pieces: Map[Pos, ChessPiece], captures: Array[ChessPiece]) 
   }
 
   def draw() = {
-    val rows = {
-      (1 to 8).reverse map Row
-    }.toArray
-
-    rows foreach {
-      _.draw(pieces)
+    def drawRows() = (1 to 8).reverse map Row foreach (_.draw(pieces))
+    
+    def printFiles() = {
+      import SquareDimensions._
+      print(EdgePadding)
+      ('a' to 'h') foreach (file => print(" " * midWidth + file + " " * (midWidth - 1)))
+      println()
     }
+    
+    drawRows()
+    printFiles()
   }
 }
 
@@ -100,6 +104,9 @@ object SquareDimensions {
   val height = 3
   val width = 5
   val midHeight = height/2 + 1
+  val midWidth = width/2 + 1
+  final val EdgePadding = "  "
+  final val Edge = EdgePadding + "-" * (width + 1) * 8
 }
 
 case class Row(rank: Int){
@@ -117,9 +124,9 @@ case class Row(rank: Int){
   def draw(pieces: Map[Pos, ChessPiece]) = {
     import SquareDimensions._
 
-    val edge = "-" * (width + 1) * 8
-    println(edge)
+    println(Edge)
     (1 to height) foreach { line =>
+      print(s"""${if (line == midHeight) rank else " "} """)
       ('a' to 'h') foreach { file =>
         print("|")
         if (line == midHeight) {
@@ -135,6 +142,6 @@ case class Row(rank: Int){
       println()
     }
     if (rank == 1)
-      println(edge)
+      println(Edge)
   }
 }

--- a/src/chess/GameBoard.scala
+++ b/src/chess/GameBoard.scala
@@ -126,7 +126,7 @@ case class Row(rank: Int){
 
     println(Edge)
     (1 to height) foreach { line =>
-      print(s"""${if (line == midHeight) rank else " "} """)
+      print(s"""${if (line == midHeight) s"$rank " else EdgePadding}""")
       ('a' to 'h') foreach { file =>
         print("|")
         if (line == midHeight) {


### PR DESCRIPTION
@karin- `SquareDimensions` is probably not the best place for `EdgePadding` and `Edge` but this approach required the least change. I tested on a bigger board (5 x 7) and it also printed the rank and file correctly. We probably want to pass the board dimensions as params to `Game.newGame` - that way you can change the size without recompiling.
